### PR TITLE
Replaces GradientDrawable with PaintDrawable

### DIFF
--- a/Chip/app/src/main/java/com/robertlevonyan/views/chip/Chip.java
+++ b/Chip/app/src/main/java/com/robertlevonyan/views/chip/Chip.java
@@ -5,7 +5,7 @@ import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.PaintDrawable;
 import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
@@ -314,9 +314,8 @@ public class Chip extends RelativeLayout {
     }
 
     private void initBackgroundColor() {
-        GradientDrawable bgDrawable = new GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, new int[]{
-                clicked ? selectedBackgroundColor : backgroundColor,
-                clicked ? selectedBackgroundColor : backgroundColor}
+        PaintDrawable bgDrawable = new PaintDrawable(
+                clicked ? selectedBackgroundColor : backgroundColor
         );
         bgDrawable.setCornerRadius(getResources().getDimension(R.dimen.chip_height) / 2);
 


### PR DESCRIPTION
Replaces GradientDrawable with PaintDrawable, thus avoid the use of a
more expensive resource, once you are using a solid color as background.