### PR TITLE
Make the whole chip selectable

### DIFF
--- a/Chip/app/src/main/java/com/robertlevonyan/views/chip/Chip.java
+++ b/Chip/app/src/main/java/com/robertlevonyan/views/chip/Chip.java
@@ -120,6 +120,17 @@ public class Chip extends RelativeLayout {
         }
     }
 
+    @Override
+    public void setSelected(boolean select) {
+        onSelectTouchDown();
+        onSelectTouchUp(selectIcon);
+    }
+
+    @Override
+    public boolean isSelected() {
+        return this.selected;
+    }
+
     private void buildView() {
         isCreated = true;
         initBackgroundColor();


### PR DESCRIPTION
Hi Robert, I've had the necessity of making the whole Chip selectable when the selectIcon is enabled, It's just following the logic you have for the select flow.

I'm aware of the unused boolean inside the setSelected method, but that way View's setSelected method can be overridden in order to avoid confusions.