### PR TITLE
Allow for text of length < 2 characters

### DIFF
--- a/Chip/app/build.gradle
+++ b/Chip/app/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.2.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/Chip/app/src/main/java/com/robertlevonyan/views/chip/ChipUtils.java
+++ b/Chip/app/src/main/java/com/robertlevonyan/views/chip/ChipUtils.java
@@ -111,7 +111,7 @@ class ChipUtils {
     }
 
     public static String generateText(String iconText) {
-        if (iconText.length() == 2) {
+        if (iconText.length() <= 2) {
             return iconText;
         }
 


### PR DESCRIPTION
This simple change should allow for icon text with a length of less than 2 characters.